### PR TITLE
Fix Helm chart version to 53.2.2

### DIFF
--- a/charts/chart/Chart.yaml
+++ b/charts/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kubeshark
-version: "53.2.0"
+version: "53.2.2"
 description: The API Traffic Analyzer for Kubernetes
 home: https://kubeshark.com
 keywords:


### PR DESCRIPTION
## Summary
- The merged `helm-v53.2.2` PR had chart version `53.2.0` instead of `53.2.2`
- This caused the chart-releaser workflow to fail with `already_exists` error
- Fixes the version so the release workflow can succeed

## Test plan
- [ ] Verify chart-releaser workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)