### PR TITLE
Fix Helm chart version to 53.2.3

### DIFF
--- a/charts/chart/Chart.yaml
+++ b/charts/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kubeshark
-version: "53.2.2"
+version: "53.2.3"
 description: The API Traffic Analyzer for Kubernetes
 home: https://kubeshark.com
 keywords:


### PR DESCRIPTION
Bumps `charts/chart/Chart.yaml` to `53.2.3` so that the chart-releaser action creates the `kubeshark-53.2.3` release. The v53.2.3 release PR (#6) did not include the version bump, which caused chart-releaser to re-package `kubeshark-53.2.2` and fail with a 422 `already_exists` error.